### PR TITLE
fix: fetch all dataset fallback partitions

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import time
 from datetime import datetime, timezone
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 REPORIUM_API_URL = os.getenv("REPORIUM_API_URL", "")
 TIMEOUT = 15
 FORK_TABLE_LIMIT = 100
+FULL_PARTITION_SIZE = 10_000
 
 
 # ── API fetching ───────────────────────────────────────────────────────────────
@@ -338,6 +340,34 @@ async def _db_get(url: str, token: str) -> Optional[Any]:
         return None
 
 
+async def _fetch_fallback_partitions(total_repos: int, token: str) -> list[dict]:
+    """Fetch all raw dataset partitions needed to cover the current repo count.
+
+    reporium-db writes full dataset partitions as full/repos_XXXX.json in 10K-repo chunks.
+    Reading only repos_0000.json silently truncates the fallback once the dataset grows past
+    the first partition, so we fetch every partition implied by the reported total.
+    """
+    if total_repos <= 0:
+        return []
+
+    import asyncio
+
+    partition_count = max(1, math.ceil(total_repos / FULL_PARTITION_SIZE))
+    urls = [
+        f"{_DB_RAW_BASE}/full/repos_{idx:04d}.json"
+        for idx in range(partition_count)
+    ]
+    payloads = await asyncio.gather(*[_db_get(url, token) for url in urls])
+
+    repos: list[dict] = []
+    for idx, payload in enumerate(payloads):
+        if isinstance(payload, list):
+            repos.extend(payload)
+        else:
+            logger.warning("Missing or invalid fallback partition %s", urls[idx])
+    return repos
+
+
 async def _fetch_fallback(token: str) -> tuple[Optional[dict], Optional[list]]:
     """Fallback: read stats and repos from reporium-db raw files.
 
@@ -346,10 +376,7 @@ async def _fetch_fallback(token: str) -> tuple[Optional[dict], Optional[list]]:
     """
     import asyncio
 
-    index, raw_repos = await asyncio.gather(
-        _db_get(f"{_DB_RAW_BASE}/index.json", token),
-        _db_get(f"{_DB_RAW_BASE}/full/repos_0000.json", token),
-    )
+    index = await _db_get(f"{_DB_RAW_BASE}/index.json", token)
 
     stats: Optional[dict] = None
     if index:
@@ -361,6 +388,11 @@ async def _fetch_fallback(token: str) -> tuple[Optional[dict], Optional[list]]:
         }
 
     repos: Optional[list] = None
+    if stats:
+        raw_repos = await _fetch_fallback_partitions(stats["total_repos"], token)
+    else:
+        raw_repos = []
+
     if raw_repos:
         repos = []
         for r in raw_repos:

--- a/generate.py
+++ b/generate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import os
@@ -23,6 +24,9 @@ REPORIUM_API_URL = os.getenv("REPORIUM_API_URL", "")
 TIMEOUT = 15
 FORK_TABLE_LIMIT = 100
 FULL_PARTITION_SIZE = 10_000
+LEGACY_REPO_ALIASES = {
+    "perditioinc/repo-intelligence": "perditioinc/reporium-scoring",
+}
 
 
 # ── API fetching ───────────────────────────────────────────────────────────────
@@ -126,6 +130,16 @@ def _lang_list(languages: dict[str, int]) -> str:
     """Top 10 languages as a markdown bullet list."""
     items = list(languages.items())[:10]
     return "\n".join(f"- **{lang}**: {count:,} repos" for lang, count in items)
+
+
+def _canonical_repo_identity(owner: str, name: str, github_url: Optional[str] = None) -> tuple[str, str, str]:
+    """Normalize legacy repo names and URLs to the current canonical identity."""
+    full_name = f"{owner}/{name}" if owner and name else ""
+    canonical_full_name = LEGACY_REPO_ALIASES.get(full_name, full_name)
+    if "/" in canonical_full_name:
+        owner, name = canonical_full_name.split("/", 1)
+    canonical_url = f"https://github.com/{canonical_full_name}" if canonical_full_name else (github_url or "")
+    return owner, name, canonical_url
 
 
 def _personal_repos_table(repos: list[dict]) -> str:
@@ -350,7 +364,6 @@ async def _fetch_fallback_partitions(total_repos: int, token: str) -> list[dict]
     if total_repos <= 0:
         return []
 
-    import asyncio
 
     partition_count = max(1, math.ceil(total_repos / FULL_PARTITION_SIZE))
     urls = [
@@ -374,7 +387,6 @@ async def _fetch_fallback(token: str) -> tuple[Optional[dict], Optional[list]]:
     Converts reporium-db schema to the same shape build_readme expects.
     Used when REPORIUM_API_URL is not configured.
     """
-    import asyncio
 
     index = await _db_get(f"{_DB_RAW_BASE}/index.json", token)
 
@@ -430,7 +442,6 @@ async def main() -> None:
     Tries reporium-api first; falls back to reporium-db raw files if the
     API URL is not configured or the request fails.
     """
-    import asyncio
 
     t0 = time.monotonic()
     api_url = REPORIUM_API_URL
@@ -456,6 +467,5 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    import asyncio
 
     asyncio.run(main())

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -10,6 +10,8 @@ import respx
 from generate import (
     _api_get,
     _fetch_all_repos,
+    _fetch_fallback,
+    _fetch_fallback_partitions,
     _fetch_stats,
     _fork_display,
     _freshness_label,
@@ -259,3 +261,43 @@ async def test_fetch_stats_returns_none_on_failure():
     respx.get(f"{API_BASE}/library").mock(side_effect=httpx.ConnectError("refused"))
     result = await _fetch_stats(API_BASE)
     assert result is None
+
+
+@respx.mock
+async def test_fetch_fallback_partitions_reads_all_needed_partitions():
+    """Fallback should fetch every full dataset partition implied by total_repos."""
+    respx.get("https://raw.githubusercontent.com/perditioinc/reporium-db/main/data/full/repos_0000.json").mock(
+        return_value=httpx.Response(200, json=[{"nameWithOwner": "org/repo-1"}])
+    )
+    respx.get("https://raw.githubusercontent.com/perditioinc/reporium-db/main/data/full/repos_0001.json").mock(
+        return_value=httpx.Response(200, json=[{"nameWithOwner": "org/repo-2"}])
+    )
+
+    repos = await _fetch_fallback_partitions(10001, token="")
+    assert [repo["nameWithOwner"] for repo in repos] == ["org/repo-1", "org/repo-2"]
+
+
+@respx.mock
+async def test_fetch_fallback_uses_partition_count_from_index():
+    """Fallback end-to-end should aggregate repos from all declared partitions."""
+    respx.get("https://raw.githubusercontent.com/perditioinc/reporium-db/main/data/index.json").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "meta": {"total": 10001, "last_updated": "2026-03-23T00:00:00+00:00"},
+                "languages": {"Python": 2},
+            },
+        )
+    )
+    respx.get("https://raw.githubusercontent.com/perditioinc/reporium-db/main/data/full/repos_0000.json").mock(
+        return_value=httpx.Response(200, json=[{"nameWithOwner": "org/repo-1", "description": "", "isFork": False}])
+    )
+    respx.get("https://raw.githubusercontent.com/perditioinc/reporium-db/main/data/full/repos_0001.json").mock(
+        return_value=httpx.Response(200, json=[{"nameWithOwner": "org/repo-2", "description": "", "isFork": True}])
+    )
+
+    stats, repos = await _fetch_fallback(token="")
+    assert stats is not None
+    assert stats["total_repos"] == 10001
+    assert repos is not None
+    assert len(repos) == 2


### PR DESCRIPTION
## Changes
- Fetch every reporium-db fallback partition implied by the reported repo count
- Stop truncating fallback data at ull/repos_0000.json
- Add regression coverage for partition-aware fallback loading

## Audit Reference
Codex suite audit finding P1-8: dataset fallback only reads the first partition and silently breaks past 10K repos

## Testing
- python -m compileall generate.py tests passes
- pytest is not installed in this environment, so test execution was not available