### PR TITLE
Governance: metadata-guard + estimate/actual time-tracking enforcement

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,42 @@
+name: Task
+description: Standard work item - enforced metadata (assignee/labels/milestone/estimate still set after creation)
+labels: ["needs-metadata"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      options: [feature, fix, chore, docs, security, spike]
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [P0, P1, P2, P3]
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      description: "e.g. reporium, anomra, infra, platform"
+    validations:
+      required: true
+  - type: input
+    id: estimate
+    attributes:
+      label: Estimate (hrs)
+      description: "Estimated hours to complete"
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: Detail
+      description: What, why, acceptance criteria
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: "After creating: set the Assignee, the P0-P3 + area:/type: labels, the Milestone, add to the Perditio-Labs Work Board, and fill the Estimate field. metadata-guard will flag the issue until these are set."

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- metadata-guard enforces these. A PR missing any required field FAILS the check (blocks merge). -->
+
+## Summary
+<!-- what changed + why -->
+
+## Linked issue
+Closes #
+
+## Metrics (required - GitFlow time tracking)
+- Estimate (hrs):
+- Actual (hrs):
+- Risk tier: <!-- T0 | T1 | T2 | T3 -->
+
+## Required metadata checklist
+- [ ] Assignee set
+- [ ] Priority label (P0-P3) + `area:`/`type:` label
+- [ ] Milestone set
+- [ ] On the Perditio-Labs Work Board (private)
+- [ ] Reviewer requested (per risk tier)
+- [ ] Estimate + Actual filled above

--- a/.github/workflows/metadata-guard.yml
+++ b/.github/workflows/metadata-guard.yml
@@ -1,0 +1,45 @@
+name: metadata-guard
+on:
+  issues:
+    types: [opened, edited, reopened]
+  pull_request:
+    types: [opened, edited, reopened, ready_for_review, synchronize]
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+jobs:
+  guard:
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const obj = isPR ? context.payload.pull_request : context.payload.issue;
+            const labels = (obj.labels || []).map(l => l.name);
+            const body = obj.body || '';
+            const missing = [];
+            if (!obj.assignees || obj.assignees.length === 0) missing.push('assignee');
+            if (!labels.some(l => /^P[0-3]$/.test(l))) missing.push('priority label (P0-P3)');
+            if (!labels.some(l => l.startsWith('area:') || l.startsWith('type:'))) missing.push('area:/type: label');
+            if (!obj.milestone) missing.push('milestone');
+            if (!/Estimate[^\n]*\d/i.test(body)) missing.push('Estimate (hrs)');
+            if (isPR) {
+              if (!/Actual[^\n]*\d/i.test(body)) missing.push('Actual (hrs)');
+              if (!/(closes|fixes|resolves)\s+#\d+/i.test(body)) missing.push('linked issue (Closes #N)');
+              const revs = (context.payload.pull_request.requested_reviewers || []).length + (context.payload.pull_request.requested_teams || []).length;
+              if (revs === 0) missing.push('reviewer');
+            }
+            const n = obj.number;
+            if (missing.length) {
+              const msg = 'metadata-guard: missing required field(s) -> ' + missing.join(', ') +
+                '. See governance/metrics-and-metadata-standard.md. Every ' + (isPR ? 'PR' : 'issue') +
+                ' needs assignee + priority + area/type label + milestone + Estimate' +
+                (isPR ? ' + Actual + linked issue + reviewer' : '') + '.';
+              await github.rest.issues.createComment({ ...context.repo, issue_number: n, body: msg });
+              if (isPR) { core.setFailed(msg); }
+              else { try { await github.rest.issues.addLabels({ ...context.repo, issue_number: n, labels: ['needs-metadata'] }); } catch (e) {} }
+            } else if (!isPR) {
+              try { await github.rest.issues.removeLabel({ ...context.repo, issue_number: n, name: 'needs-metadata' }); } catch (e) {}
+            }


### PR DESCRIPTION
Adds metadata-guard workflow (hard-fails PRs / flags issues lacking assignee, priority+area labels, milestone, Estimate; +Actual/linked-issue/reviewer on PRs) and labels. Added: metadata-guard.yml, task.yml, PR-template. Standard: perditio-security/governance/metrics-and-metadata-standard.md.